### PR TITLE
feat : calendar page prototype

### DIFF
--- a/forever_planner/src/components/Calendar/CalendarVue.vue
+++ b/forever_planner/src/components/Calendar/CalendarVue.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="bg-white w-full h-full rounded-3xl flex flex-col">
+    <WeekVue class="w-full"/>
+    <DateVue class="w-full"/>
+  </div>
+</template>
+
+<script setup>
+import DateVue from './DateVue.vue'
+import WeekVue from './WeekVue.vue'
+</script>
+
+<style scoped>
+</style>

--- a/forever_planner/src/components/Calendar/Date.vue
+++ b/forever_planner/src/components/Calendar/Date.vue
@@ -1,9 +1,0 @@
-<script setup>
-
-</script>
-
-<template>
-  <div class="bg-white"></div>
-</template>
-
-<style></style>

--- a/forever_planner/src/components/Calendar/DateVue.vue
+++ b/forever_planner/src/components/Calendar/DateVue.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="flex flex-col h-full justify-between text-2xs">
+    <div v-for="week in 5" :key="week" class="flex w-full h-full">
+      <div v-for="date in 7" :key="date" class="w-full h-full flex flex-col items-center justify-start">
+        <div class="pb-0.5">{{ date }}</div>
+        <PostVue />
+        <FinishedPostVue />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import PostVue from './PostVue.vue';
+import FinishedPostVue from './FinishiedPostVue.vue';
+</script>
+
+<style scoped>
+</style>

--- a/forever_planner/src/components/Calendar/FinishiedPostVue.vue
+++ b/forever_planner/src/components/Calendar/FinishiedPostVue.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="p-0.5 w-full">
+    <div class="bg-[#e4eefc] w-full rounded text-2xs flex h-full">
+      <div class="w-1 rounded-l h-full bg-[#a7c8f7]"></div>
+      <div class="w-full p-[0.5px] flex items-center justify-center">방학</div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+
+</script>
+
+<style scoped>
+
+</style>

--- a/forever_planner/src/components/Calendar/PostVue.vue
+++ b/forever_planner/src/components/Calendar/PostVue.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="p-0.5 w-full">
+    <div class="bg-[#e4eefc] w-full rounded text-2xs p-[0.5px] flex items-center justify-center">방학</div>
+  </div>
+</template>
+
+<script setup>
+
+</script>
+
+<style scoped>
+
+</style>

--- a/forever_planner/src/components/Calendar/WeekVue.vue
+++ b/forever_planner/src/components/Calendar/WeekVue.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="flex justify-between py-3 text-2xs">
+    <div v-for="week in weeks" :key="week" class="w-full flex items-center justify-center">{{ week }}</div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+const weeks = ref(["일", "월", "화", "수", "목", "금", "토"])
+</script>
+
+<style scoped>
+</style>

--- a/forever_planner/src/views/CalendarView.vue
+++ b/forever_planner/src/views/CalendarView.vue
@@ -1,10 +1,12 @@
 <template>
-  <div>
-    <h1 class="bg-black text-white">Calendar View</h1>
+  <div class="w-full h-screen bg-[#f5f7fd] p-2 flex flex-col justify-end">
+    <div class="text-2xl font-semibold p-3">7월</div>
+    <CalendarVue class="w-full h-full"/>
   </div>
 </template>
 
-<script>
+<script setup>
+import CalendarVue from '@/components/Calendar/CalendarVue.vue'
 </script>
 
 <style scoped>

--- a/forever_planner/tailwind.config.js
+++ b/forever_planner/tailwind.config.js
@@ -5,7 +5,14 @@ module.exports = {
     "./src/**/*.{vue,js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontSize: {
+        '3xs': '0.5rem', // 8px
+        '2xs': '0.625rem', // 10px
+        '3xl': '1.75rem', // 28px
+        '10xl': '6.25rem', //100px
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Docs
- [figma](https://www.figma.com/design/quF1ystEYNNBJzr6pTInPc/%EC%A0%84%EA%B4%91%EC%9D%BC?node-id=30-2&t=mIFgJpnrHkDWPn3v-1)

## Changes
- before : 
FE, BE 기본세팅

- after : 
캘린더 페이지 퍼블리싱

- images
<img width="336" alt="image" src="https://github.com/user-attachments/assets/d21fee6b-ca63-46cf-b720-d0676eacb445">

## Review Points
- 캘린더 페이지가 깨짐 없이 구현 되었는가

## Test Checklist
- [x] 페이지 레이아웃이 깨지는지 확인